### PR TITLE
fix: avoid superfluous ALTER TABLE migrations

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -339,14 +339,14 @@ fn compare_create_table(a: &CreateTable, b: &CreateTable) -> Option<Vec<Statemen
         return None;
     }
 
-    let a_column_names: HashSet<_> = a.columns.iter().map(|c| c.name.clone()).collect();
-    let b_column_names: HashSet<_> = b.columns.iter().map(|c| c.name.clone()).collect();
+    let a_column_names: HashSet<_> = a.columns.iter().map(|c| c.name.value.clone()).collect();
+    let b_column_names: HashSet<_> = b.columns.iter().map(|c| c.name.value.clone()).collect();
 
     let operations: Vec<_> = a
         .columns
         .iter()
         .filter_map(|ac| {
-            if b_column_names.contains(&ac.name) {
+            if b_column_names.contains(&ac.name.value) {
                 None
             } else {
                 // drop column if it only exists in `a`
@@ -359,7 +359,7 @@ fn compare_create_table(a: &CreateTable, b: &CreateTable) -> Option<Vec<Statemen
             }
         })
         .chain(b.columns.iter().filter_map(|bc| {
-            if a_column_names.contains(&bc.name) {
+            if a_column_names.contains(&bc.name.value) {
                 None
             } else {
                 // add the column if it only exists in `b`

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -342,7 +342,7 @@ fn compare_create_table(a: &CreateTable, b: &CreateTable) -> Option<Vec<Statemen
     let a_column_names: HashSet<_> = a.columns.iter().map(|c| c.name.clone()).collect();
     let b_column_names: HashSet<_> = b.columns.iter().map(|c| c.name.clone()).collect();
 
-    let ops = a
+    let operations: Vec<_> = a
         .columns
         .iter()
         .filter_map(|ac| {
@@ -373,11 +373,15 @@ fn compare_create_table(a: &CreateTable, b: &CreateTable) -> Option<Vec<Statemen
         }))
         .collect();
 
+    if operations.is_empty() {
+        return None;
+    }
+
     Some(vec![Statement::AlterTable {
         name: a.name.clone(),
         if_exists: a.if_not_exists,
         only: false,
-        operations: ops,
+        operations,
         location: None,
         on_cluster: a.on_cluster.clone(),
         iceberg: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,17 +173,41 @@ mod tests {
     #[test]
     fn diff_create_table() {
         run_test_cases(
-            vec![TestCase {
-                dialect: Dialect::Generic,
-                sql_a: "CREATE TABLE foo(\
+            vec![
+                TestCase {
+                    dialect: Dialect::Generic,
+                    sql_a: "CREATE TABLE foo(\
                             id int PRIMARY KEY
                         )",
-                sql_b: "CREATE TABLE foo(\
+                    sql_b: "CREATE TABLE foo(\
                             id int PRIMARY KEY
                         );\
                         CREATE TABLE bar (id INT PRIMARY KEY);",
-                expect: "CREATE TABLE bar (id INT PRIMARY KEY);",
-            }],
+                    expect: "CREATE TABLE bar (id INT PRIMARY KEY);",
+                },
+                TestCase {
+                    dialect: Dialect::Generic,
+                    sql_a: "CREATE TABLE foo(\
+                            id int PRIMARY KEY
+                        )",
+                    sql_b: "CREATE TABLE foo(\
+                            \"id\" int PRIMARY KEY
+                        );\
+                        CREATE TABLE bar (id INT PRIMARY KEY);",
+                    expect: "CREATE TABLE bar (id INT PRIMARY KEY);",
+                },
+                TestCase {
+                    dialect: Dialect::Generic,
+                    sql_a: "CREATE TABLE foo(\
+                            \"id\" int PRIMARY KEY
+                        )",
+                    sql_b: "CREATE TABLE foo(\
+                            id int PRIMARY KEY
+                        );\
+                        CREATE TABLE bar (id INT PRIMARY KEY);",
+                    expect: "CREATE TABLE bar (id INT PRIMARY KEY);",
+                },
+            ],
             |ast_a, ast_b| ast_a.diff(&ast_b),
         );
     }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -265,7 +265,7 @@ fn migrate_alter_table(
                 t.columns.push(column_def.clone());
             }
             AlterTableOperation::DropColumn { column_name, .. } => {
-                t.columns.retain(|c| c.name != *column_name);
+                t.columns.retain(|c| c.name.value != *column_name.value);
             }
             AlterTableOperation::AlterColumn { column_name, op } => {
                 t.columns.iter_mut().for_each(|c| {


### PR DESCRIPTION
There's still work to be done around altering columns (see #7), but this PR avoids generating an `ALTER TABLE` statement when there are no operations to perform, and compares column names independently of quote style.